### PR TITLE
Add ServiciosWebX library and integrate with ProyectoWeb

### DIFF
--- a/ProyectoWeb/build.xml
+++ b/ProyectoWeb/build.xml
@@ -130,7 +130,10 @@
 	<property name="docs.home"     		value="${basedir}/docs"/>
 	<property name="src.dir"      		value="${basedir}/src/"/>
 	<property name="src.main"      		value="${basedir}/src/main"/>
-	<property name="dependencies"       value="${basedir}/lib"/>
+        <property name="dependencies"       value="${basedir}/lib"/>
+        <!-- ServiciosWebX project location -->
+        <property name="servicioswebx.home" value="${basedir}/../ServiciosWebX"/>
+        <property name="servicioswebx.jar" value="${servicioswebx.home}/dist/ServiciosWebX.jar"/>
 	<property name="resources.dir" 		value="${src.dir}/resources"/>
 	<property name="jsp.dir" 			value="${src.dir}/jsp"/>
 	<property name="config.dir" 		value="${src.dir}/config"/>
@@ -187,9 +190,10 @@
 		<!--
     <pathelement location="${foo.jar}"/>
 -->
-		<fileset dir="${dependencies}">
-			<include name="*.jar"/>
-		</fileset>
+                <fileset dir="${dependencies}">
+                        <include name="*.jar"/>
+                </fileset>
+                <pathelement location="${servicioswebx.jar}"/>
 
 		<!-- Include all elements that Tomcat exposes to applications -->
 		<fileset dir="${appserver.home}/bin">
@@ -202,16 +206,17 @@
 	</path>
 
 
-	<path id="test.classpath">
+        <path id="test.classpath">
 
 		<!-- Include all JAR files that will be included in /WEB-INF/lib -->
 		<!-- *** CUSTOMIZE HERE AS REQUIRED BY YOUR APPLICATION *** -->
 		<!--
     <pathelement location="${foo.jar}"/>
 -->
-		<fileset dir="${dependencies}">
-			<include name="*.jar"/>
-		</fileset>
+                <fileset dir="${dependencies}">
+                        <include name="*.jar"/>
+                </fileset>
+                <pathelement location="${servicioswebx.jar}"/>
 
 		<!-- Include all elements that TcompileTestsomcat exposes to applications -->
 		<fileset dir="${appserver.home}/bin">
@@ -310,8 +315,12 @@
 
 -->
 
-	<target name="compile" depends="clean, prepare"
-   		description="Compile Java sources">
+        <target name="buildServiciosWebX">
+                <ant dir="${servicioswebx.home}" target="jar"/>
+        </target>
+
+        <target name="compile" depends="clean, buildServiciosWebX, prepare"
+                description="Compile Java sources">
 
 		<!-- Compile Java classes as necessary -->
 		<javac srcdir="${src.main}"
@@ -543,12 +552,13 @@
 
 		<!-- Copy external dependencies as required -->
 		<!-- *** CUSTOMIZE HERE AS REQUIRED BY YOUR APPLICATION *** -->
-		<copy  todir="${build.home}/WEB-INF/lib">
-			<fileset dir="${dependencies}/">
-				<include name="*.jar"/>
-			</fileset>
-		</copy>
-	</target>
+                <copy  todir="${build.home}/WEB-INF/lib">
+                        <fileset dir="${dependencies}/">
+                                <include name="*.jar"/>
+                        </fileset>
+                </copy>
+                <copy file="${servicioswebx.jar}" todir="${build.home}/WEB-INF/lib"/>
+        </target>
 
 
 	<!-- ==================== Reload Target =================================== -->

--- a/ServiciosWebX/build.xml
+++ b/ServiciosWebX/build.xml
@@ -1,0 +1,29 @@
+<project name="ServiciosWebX" default="jar" basedir=".">
+    <property name="src.dir" value="src/main"/>
+    <property name="build.dir" value="build"/>
+    <property name="dist.dir" value="dist"/>
+    <property name="dependencies" value="${basedir}/../ProyectoWeb/lib"/>
+
+    <path id="compile.classpath">
+        <fileset dir="${dependencies}">
+            <include name="*.jar"/>
+        </fileset>
+    </path>
+
+    <target name="clean">
+        <delete dir="${build.dir}"/>
+        <delete dir="${dist.dir}"/>
+    </target>
+
+    <target name="compile" depends="clean">
+        <mkdir dir="${build.dir}"/>
+        <javac srcdir="${src.dir}" destdir="${build.dir}" source="1.8" target="1.8">
+            <classpath refid="compile.classpath"/>
+        </javac>
+    </target>
+
+    <target name="jar" depends="compile">
+        <mkdir dir="${dist.dir}"/>
+        <jar destfile="${dist.dir}/ServiciosWebX.jar" basedir="${build.dir}"/>
+    </target>
+</project>

--- a/ServiciosWebX/src/main/java/com/servicioswebx/Utilidades.java
+++ b/ServiciosWebX/src/main/java/com/servicioswebx/Utilidades.java
@@ -1,0 +1,7 @@
+package com.servicioswebx;
+
+public class Utilidades {
+    public static int sumar(int a, int b) {
+        return a + b;
+    }
+}


### PR DESCRIPTION
## Summary
- add ServiciosWebX simple Java library with Utilidades class
- include ServiciosWebX jar in ProyectoWeb build
- build ServiciosWebX before compiling ProyectoWeb
- copy ServiciosWebX jar into WAR lib folder

## Testing
- `ant jar -q` in ServiciosWebX
- `ant compile -q` in ProyectoWeb *(fails: missing servlet classes)*

------
https://chatgpt.com/codex/tasks/task_b_6866b3c2cfc08332ba223bc7d73d0c89