### PR TITLE
Add Gradle dependency management

### DIFF
--- a/ProyectoWeb/README.md
+++ b/ProyectoWeb/README.md
@@ -3,7 +3,16 @@ spring-antbuild
 
 Project based on http://docs.spring.io/docs/Spring-MVC-step-by-step adapted as per tomcat deployment guide.
 
-Eclipse project files included with all dependant jars.
+Dependencies are now managed with Gradle.
+
+Run the following command before using Ant so the required JARs are copied to
+`ProyectoWeb/lib` and later packaged in the WAR:
+
+```
+gradle copyDependencies
+```
+
+Eclipse project files included with all dependant jars remain for convenience.
 
 Start DB: 
 	java -classpath dependencies/hsqldb-2.3.2.jar org.hsqldb.Server -database test

--- a/ProyectoWeb/build.xml
+++ b/ProyectoWeb/build.xml
@@ -315,11 +315,17 @@
 
 -->
 
+        <target name="resolve">
+                <exec executable="gradle">
+                        <arg value="copyDependencies"/>
+                </exec>
+        </target>
+
         <target name="buildServiciosWebX">
                 <ant dir="${servicioswebx.home}" target="jar"/>
         </target>
 
-        <target name="compile" depends="clean, buildServiciosWebX, prepare"
+        <target name="compile" depends="clean, resolve, buildServiciosWebX, prepare"
                 description="Compile Java sources">
 
 		<!-- Compile Java classes as necessary -->

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,50 @@
+plugins {
+    id 'base'
+}
+
+repositories {
+    mavenCentral()
+}
+
+configurations {
+    libs {
+        transitive = false
+    }
+}
+
+dependencies {
+    libs 'aopalliance:aopalliance:1.0'
+    libs 'org.aspectj:aspectjweaver:1.8.1'
+    libs 'commons-dbcp:commons-dbcp:1.4'
+    libs 'commons-logging:commons-logging:1.2'
+    libs 'commons-pool:commons-pool:1.6'
+    libs 'org.hsqldb:hsqldb:2.3.2'
+    libs 'javax.servlet:jstl:1.2'
+    libs 'javax.servlet:servlet-api:2.5'
+    libs 'junit:junit:4.11'
+    libs 'log4j:log4j:1.2.17'
+    libs 'org.springframework:spring-aop:3.2.1.RELEASE'
+    libs 'org.springframework:spring-aspects:3.2.1.RELEASE'
+    libs 'org.springframework:spring-beans:3.2.1.RELEASE'
+    libs 'org.springframework:spring-context:3.2.1.RELEASE'
+    libs 'org.springframework:spring-context-support:3.2.1.RELEASE'
+    libs 'org.springframework:spring-core:3.2.1.RELEASE'
+    libs 'org.springframework:spring-expression:3.2.1.RELEASE'
+    libs 'org.springframework:spring-instrument:3.2.1.RELEASE'
+    libs 'org.springframework:spring-instrument-tomcat:3.2.1.RELEASE'
+    libs 'org.springframework:spring-jdbc:3.2.1.RELEASE'
+    libs 'org.springframework:spring-jms:3.2.1.RELEASE'
+    libs 'org.springframework:spring-orm:3.2.1.RELEASE'
+    libs 'org.springframework:spring-oxm:3.2.1.RELEASE'
+    libs 'org.springframework:spring-struts:3.2.1.RELEASE'
+    libs 'org.springframework:spring-test:3.2.1.RELEASE'
+    libs 'org.springframework:spring-tx:3.2.1.RELEASE'
+    libs 'org.springframework:spring-web:3.2.1.RELEASE'
+    libs 'org.springframework:spring-webmvc:3.2.1.RELEASE'
+    libs 'org.springframework:spring-webmvc-portlet:3.2.1.RELEASE'
+}
+
+task copyDependencies(type: Copy) {
+    from configurations.libs
+    into "ProyectoWeb/lib"
+}


### PR DESCRIPTION
## Summary
- introduce `build.gradle` to resolve project libraries
- trigger Gradle from Ant build before compiling
- document the new step in the README

## Testing
- `gradle copyDependencies --quiet`
- `ant compile -quiet`

------
https://chatgpt.com/codex/tasks/task_b_686c3a3ee93c83329ce4d55f577e0225